### PR TITLE
增加options请求方式，添加CORS跨域

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,6 +137,14 @@ Server.prototype = {
       handler.call(_this, req, res, match, options);
     });
   },
+  
+  "options": function (path, options) {
+    var _this = this;
+
+    router.addRoute("OPTIONS" + path, function (req, res, match) {
+      handler.call(_this, req, res, match, options);
+    });
+  },
 
   // 使用代理
   'proxy': function (path, options) {

--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ var Router = require("routes"),
 var router = Router(),
     header = {
       'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'POST, GET, DELETE, PUT, PATCH, OPTIONS'
+      'Access-Control-Allow-Methods': 'POST, GET, DELETE, PUT, PATCH, OPTIONS',
+      'Access-Control-Allow-Headers': 'X-Requested-With, Content-Type'
     };
 
 /**

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ var Router = require("routes"),
 var router = Router(),
     header = {
       'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'POST, GET, DELETE, PUT, PATCH'
+      'Access-Control-Allow-Methods': 'POST, GET, DELETE, PUT, PATCH, OPTIONS'
     };
 
 /**


### PR DESCRIPTION
在cors服务器下，会自动发起 OPTIONS 请求，如果没有设置，则会返回404，导致请求失败
